### PR TITLE
fix: removed unused %s in runtime_error

### DIFF
--- a/src/minecraft_utils.cpp
+++ b/src/minecraft_utils.cpp
@@ -91,7 +91,7 @@ void MinecraftUtils::setupHybris() {
 void* MinecraftUtils::loadMinecraftLib(std::string const& path) {
     void* handle = hybris_dlopen(path.c_str(), RTLD_LAZY);
     if (handle == nullptr)
-        throw std::runtime_error(std::string("Failed to load Minecraft: %s") + hybris_dlerror());
+        throw std::runtime_error(std::string("Failed to load Minecraft: ") + hybris_dlerror());
     HookManager::addHookLibrary(handle, path);
     return handle;
 }


### PR DESCRIPTION
or it will show as
```
terminate called after throwing an instance of 'std::runtime_error'
  what():  Failed to load Minecraft: %sCannot load library: load_library[1115]: Library 'game/libs/libminecraftpe.so' not found
Signal 6 received
```