### PR TITLE
Transition to dlext hooks for mouse visibility callbacks

### DIFF
--- a/include/mcpelauncher/minecraft_utils.h
+++ b/include/mcpelauncher/minecraft_utils.h
@@ -16,7 +16,7 @@ public:
 
     static void setupHybris();
 
-    static void* loadMinecraftLib();
+    static void* loadMinecraftLib(void *showMousePointerCallback, void *hideMousePointerCallback);
 
     static void* loadFMod();
     static void stubFMod();

--- a/src/minecraft_utils.cpp
+++ b/src/minecraft_utils.cpp
@@ -141,9 +141,12 @@ void* MinecraftUtils::loadMinecraftLib(void *showMousePointerCallback, void *hid
 // Shadowing it, avoids allways defining OPENSSL_armcap=0
     hooks.emplace_back(mcpelauncher_hook_t{ "OPENSSL_cpuid_setup", (void*) + []() -> void {} });
 #endif
-// Minecraft 1.16.210+ removes the symbols previously used to patch it via vtables, hook instead
-    hooks.emplace_back(mcpelauncher_hook_t{ "_ZN11AppPlatform16showMousePointerEv", showMousePointerCallback });
-    hooks.emplace_back(mcpelauncher_hook_t{ "_ZN11AppPlatform16hideMousePointerEv", hideMousePointerCallback });
+
+// Minecraft 1.16.210+ removes the symbols previously used to patch it via vtables, so use hooks instead if supplied
+    if (showMousePointerCallback && hideMousePointerCallback) {
+        hooks.emplace_back(mcpelauncher_hook_t{ "_ZN11AppPlatform16showMousePointerEv", showMousePointerCallback });
+        hooks.emplace_back(mcpelauncher_hook_t{ "_ZN11AppPlatform16hideMousePointerEv", hideMousePointerCallback });
+    }
 
     hooks.emplace_back(mcpelauncher_hook_t{ nullptr, nullptr });
     extinfo.flags = ANDROID_DLEXT_MCPELAUNCHER_HOOKS;

--- a/src/minecraft_utils.cpp
+++ b/src/minecraft_utils.cpp
@@ -125,28 +125,30 @@ void MinecraftUtils::setupApi() {
     linker::load_library("libmcpelauncher_mod.so", syms);
 }
 
-void* MinecraftUtils::loadMinecraftLib() {
+void* MinecraftUtils::loadMinecraftLib(void *showMousePointerCallback, void *hideMousePointerCallback) {
     linker::dlopen("libc++_shared.so", 0);
+
+    android_dlextinfo extinfo;
+    std::vector<mcpelauncher_hook_t> hooks;
 #ifdef __arm__
 // Workaround for v8 allocator crash Minecraft 1.16.100+ on a RaspberryPi2 running raspbian
 // Shadow some new overrides with host allocator fixes the crash
 // Seems to be unnecessary on a RaspberryPi4 running ubuntu arm64
-    android_dlextinfo extinfo;
-    std::vector<mcpelauncher_hook_t> hooks;
     hooks.emplace_back(mcpelauncher_hook_t{ "_Znaj", (void*)((void*(*)(std::size_t))&::operator new[]) });
     hooks.emplace_back(mcpelauncher_hook_t{ "_Znwj", (void*)((void*(*)(std::size_t))&::operator new) });
     hooks.emplace_back(mcpelauncher_hook_t{ "_ZnwjSt11align_val_t", (void*)((void*(*)(std::size_t, std::align_val_t))&::operator new[]) });
 // The Openssl cpuid setup seems to not work correctly and allways crashs with "invalid instruction" Minecraft 1.16.10 (beta 1.16.0.66) or lower
 // Shadowing it, avoids allways defining OPENSSL_armcap=0
     hooks.emplace_back(mcpelauncher_hook_t{ "OPENSSL_cpuid_setup", (void*) + []() -> void {} });
+#endif
+// Minecraft 1.16.210+ removes the symbols previously used to patch it via vtables, hook instead
+    hooks.emplace_back(mcpelauncher_hook_t{ "_ZN11AppPlatform16showMousePointerEv", showMousePointerCallback });
+    hooks.emplace_back(mcpelauncher_hook_t{ "_ZN11AppPlatform16hideMousePointerEv", hideMousePointerCallback });
 
     hooks.emplace_back(mcpelauncher_hook_t{ nullptr, nullptr });
     extinfo.flags = ANDROID_DLEXT_MCPELAUNCHER_HOOKS;
     extinfo.mcpelauncher_hooks = hooks.data();
     void* handle = linker::dlopen_ext("libminecraftpe.so", 0, &extinfo);
-#else
-    void* handle = linker::dlopen("libminecraftpe.so", 0);
-#endif
     if (handle == nullptr) {
         Log::error("MinecraftUtils", "Failed to load Minecraft: %s", linker::dlerror());
     } else {


### PR DESCRIPTION
1.16.210 removed the vtable symbols that were previously used for this
so use the linker extension as a workaround with callbacks being passed
in by the client.