### PR TITLE
modloader only load each mod once

### DIFF
--- a/include/mcpelauncher/mod_loader.h
+++ b/include/mcpelauncher/mod_loader.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <vector>
+#include <map>
 #include <string>
 #include <set>
 
@@ -10,7 +11,11 @@ class ServerInstance;
 class ModLoader {
 
 private:
-    std::vector<void*> mods;
+    struct ModMetaData {
+        bool preinit = false;
+        bool init = false;
+    };
+    std::map<void*, ModMetaData> mods;
 
     std::vector<std::string> getModDependencies(std::string const& path);
 


### PR DESCRIPTION
This change keeps track of loaded mods, if we get a well known library handle close it again and keep track of called  constructors.

This enshures mod_preinit is never called twice from the same ModLoader Object