### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,10 +16,10 @@ target_include_directories(mcpelauncher-core PRIVATE ../mcpelauncher-linker/ ../
 target_compile_definitions(mcpelauncher-core PRIVATE PATH_MAX=256 _GNU_SOURCE)
 target_compile_options(mcpelauncher-core PRIVATE -include compat.h)
 if (APPLE)
-    target_link_libraries(mcpelauncher-core osx-elf-header)
+    target_link_libraries(mcpelauncher-core PRIVATE osx-elf-header)
 endif()
 if (FREEBSD)
-    target_link_libraries(mcpelauncher-core execinfo)
+    target_link_libraries(mcpelauncher-core PRIVATE execinfo)
 endif()
 
 if (IS_ARMHF_BUILD AND NOT IS_64BIT)


### PR DESCRIPTION
In macOS, I am trying to make home-brew formula for mcpelauncher-client and mcpelauncher-ui-qt when I build the mcpelauncher-client with cmake, I encountered an error like,

> CMake Error at mcpelauncher-core/CMakeLists.txt:19 (target_link_libraries):
>   The keyword signature for target_link_libraries has already been used with
>   the target "mcpelauncher-core".  All uses of target_link_libraries with a
>   target must be either all-keyword or all-plain.
> 
>   The uses of the keyword signature are here:
> 
>    * mcpelauncher-core/CMakeLists.txt:11 (target_link_libraries)

For solving that error, I updated the target_link_libraries() with PRIVATE keyword signature which is already for "IS_ARMHF_BUILD AND NOT IS_64BIT" or "PNG_FOUND".