### PR TITLE
Fix emutls crash on macOS ARM64

### DIFF
--- a/src/minecraft_utils.cpp
+++ b/src/minecraft_utils.cpp
@@ -565,6 +565,7 @@ void* MinecraftUtils::loadMinecraftLib(void* showMousePointerCallback, void* hid
         if(__cxa_pure_virtual && __cxa_guard_acquire && __cxa_guard_release) {
             linker::relocate(libstdcxx, {{"__cxa_pure_virtual", __cxa_pure_virtual}, {"__cxa_guard_acquire", __cxa_guard_acquire}, {"__cxa_guard_release", __cxa_guard_release}});
         }
+
     }
     android_dlextinfo extinfo;
 #ifdef __arm__
@@ -595,6 +596,25 @@ void* MinecraftUtils::loadMinecraftLib(void* showMousePointerCallback, void* hid
     if(closeCallback) {
         hooks.emplace_back(mcpelauncher_hook_t{"GameActivity_finish", closeCallback});
     }
+
+    struct EmutlsControl {
+        size_t size;
+        size_t align;
+        uintptr_t index;
+        void* templ;
+    };
+    static auto __emutls_get_address = (void*(*)(EmutlsControl* ctrl))linker::dlsym(libcxx, "__emutls_get_address");
+    hooks.emplace_back(mcpelauncher_hook_t{"__emutls_get_address", (void*)+[](EmutlsControl* ctrl) {
+        double scratch;
+        if(modf(log2(ctrl->align), &scratch) != 0.0) {
+            Log::error("MinecraftUtils", "Unsupported emutls alignment %zu", ctrl->align);
+            ctrl->size = 64;
+            ctrl->align = 8;
+            ctrl->index = 0;
+            ctrl->templ = nullptr;
+        }
+        return __emutls_get_address(ctrl);
+    }});
 
     static void* fmod = nullptr;
     // Temporary feature flag to disable native fmod patching


### PR DESCRIPTION
## Summary

Hooks __emutls_get_address to correct invalid alignment values that cause crashes on macOS ARM64. Some Android libraries (loaded via the mcpelauncher linker) use emulated TLS with alignment values that are not powers of two, which the host allocator rejects.

## Changes

- Adds emutls alignment validation and correction before allocation
- Logs invalid alignment values for debugging

## Testing

This fix is required alongside mcpelauncher-client PR minecraft-linux/mcpelauncher-client#136 for Minecraft 1.26.x on macOS ARM64.

```bash
# Build steps same as mcpelauncher-client PR #136
# This branch should be checked out for mcpelauncher-core submodule
cd mcpelauncher-core
git remote add pr https://github.com/Icehunter/mcpelauncher-core.git
git fetch pr feature/gameactivity-macos-support
git checkout pr/feature/gameactivity-macos-support
```

Without this fix, the game crashes during library loading with a SIGABRT from the allocator due to non-power-of-two alignment in emulated TLS control blocks.

Tested on Apple M5 Pro, macOS 26.3, Minecraft Bedrock 1.26.10.4.

https://www.youtube.com/watch?v=lBNuIqISYa4